### PR TITLE
Adding Experimental Issue & Pull Request Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+Please fill out the form below before submitting, thank you!
+
+- [ ] Bug exists Release Version 1.0.2 (Java Repository Master Branch)
+- [ ] Bug exists in Snapshot Version 1.0.3 (Android Service Repository Master Branch)
+- [ ] Bug is just in the Sample Application.
+
+__Android API Version Bug Seen on:__
+
+__Android Version Bug Seen on:__
+
+
+Please also check that if you have found the bug in the Release version (1.0.2) that you check that it also exists in the Snapshot (1.0.3) before raising a bug.
+
+
+## Description of Bug:
+E.g. Steps to re-create, how often does this happen etc..
+
+## Console Log output (if available):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+Please make sure that the following boxes are checked before submitting your Pull Request, thank you!
+
+- [ ] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
+- [ ] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
+- [ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
+- [ ] If this is new functionality, You have added the appropriate Unit tests.


### PR DESCRIPTION
A new feature that GitHub just released is the ability to add Markdown templates to Issues and Pull Request: https://github.com/blog/2111-issue-and-pull-request-templates

I think these templates could be very valuable as a lot of bugs that are raised sometimes lack the important information needed to properly triage them. I've added some basic questions to start off with, as bugs are raised in the future, we may choose to change some of them depending on how useful they are..