### PR TITLE
fix cancel() called with a null PendingIntent

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/AlarmPingSender.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/AlarmPingSender.java
@@ -81,13 +81,13 @@ class AlarmPingSender implements MqttPingSender {
 
 	@Override
 	public void stop() {
-		// Cancel Alarm.
-		AlarmManager alarmManager = (AlarmManager) service
-				.getSystemService(Service.ALARM_SERVICE);
-		alarmManager.cancel(pendingIntent);
 
 		Log.d(TAG, "Unregister alarmreceiver to MqttService"+comms.getClient().getClientId());
 		if(hasStarted){
+			// Cancel Alarm.
+			AlarmManager alarmManager = (AlarmManager) service.getSystemService(Service.ALARM_SERVICE);
+			alarmManager.cancel(pendingIntent);
+
 			hasStarted = false;
 			try{
 				service.unregisterReceiver(alarmReceiver);


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.

In case no connection can be established, AlarmPingSender stop method will be called when it has not been started yet. `java.lang.NullPointerException: cancel() called with a null PendingIntent` will be thrown as the pending intent has not been setup yet.