### PR TITLE
Revert "Should not eat the exception, propagate it instead."

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
@@ -57,7 +57,6 @@ import android.content.ServiceConnection;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.support.v4.content.LocalBroadcastManager;
-import android.util.Log;
 import android.util.SparseArray;
 
 /**
@@ -1591,7 +1590,7 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 				// let the service discard the saved message details
 			}
 			catch (Exception e) {
-				Log.e(MqttService.TAG, "messageArrivedAction failed", e);
+				// Swallow the exception
 			}
 		}
 	}


### PR DESCRIPTION
Reverts eclipse/paho.mqtt.android#89  as this should not have been delivered to master.