### PR TITLE
Clear connecting flag when exception occured on connect. Fixed NPE.

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
@@ -295,6 +295,8 @@ class MqttConnection implements MqttCallbackExtended {
 				myClient.connect(connectOptions, invocationContext, listener);
 			}
 		} catch (Exception e) {
+			service.traceError(TAG, "Exception occurred attempting to connect: " + e.getMessage());
+			setConnectingState(false);
 			handleException(resultBundle, e);
 		}
 	}
@@ -1015,6 +1017,12 @@ class MqttConnection implements MqttCallbackExtended {
 	* multiple times 
 	*/
 	synchronized void reconnect() {
+
+		if (myClient == null) {
+			service.traceError(TAG,"Reconnect myClient = null. Will not do reconnect");
+			return;
+		}
+
 		if (isConnecting) {
 			service.traceDebug(TAG, "The client is connecting. Reconnect return directly.");
 			return ;


### PR DESCRIPTION
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [ x ] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
- [ x ] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [ x ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

Signed-off-by: miketran78727 <miketran@us.ibm.com>

A user reported 2 issues

1. NPE on reconnect 
2. Can't connect if exception was thrown on the first connect 

For the NPE, the user provided this trace:
````
2016-10-12 23:12:07 [main] ERROR (CrashExceptionHandler.java:40) -  ERROR UncaughtExceptionHandler: java.lang.RuntimeException: Error receiving broadcast Intent { act=android.net.conn.CONNECTIVITY_CHANGE flg=0x4000010 (has extras) } in org.eclipse.paho.android.service.MqttService$NetworkConnectionIntentReceiver@4196e660
	at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:769)
	at android.os.Handler.handleCallback(Handler.java:733)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:136)
	at android.app.ActivityThread.main(ActivityThread.java:5002)
	at java.lang.reflect.Method.invokeNative(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:515)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:785)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:601)
	at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.NullPointerException
	at org.eclipse.paho.android.service.MqttConnection.reconnect(MqttConnection.java:1087)
	at org.eclipse.paho.android.service.MqttService.reconnect(MqttService.java:343)
	at org.eclipse.paho.android.service.MqttService$NetworkConnectionIntentReceiver.onReceive(MqttService.java:826)
	at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:759)
````
For some reason myClient was null.  A fix for this particular issue is included in this patch.

For the second issue, this is the trace of consecutive connect() calls from the application:
````
transaction_event_15283521401298.txt:2016-10-27 17:02:46 [main] DEBUG (MqttTraceCallback.java:20) -  TRANS MQTT-TRACE: MqttConnection, Connecting {ssl://mqtt-dia-stg.cpggpc.ca:1883} as {15283521401298}
transaction_event_15283521401298.txt:2016-10-27 17:02:46 [main] DEBUG (MqttTraceCallback.java:20) -  TRANS MQTT-TRACE: MqttConnection, Do Real connect!
transaction_event_15283521401298.txt:2016-10-27 17:03:46 [main] DEBUG (MqttTraceCallback.java:20) -  TRANS MQTT-TRACE: MqttConnection, Connecting {ssl://mqtt-dia-stg.cpggpc.ca:1883} as {15283521401298}
transaction_event_15283521401298.txt:2016-10-27 17:03:46 [main] DEBUG (MqttTraceCallback.java:20) -  TRANS MQTT-TRACE: MqttConnection, myClient != null and the client is connecting. Connect return directly.
transaction_event_15283521401298.txt:2016-10-27 17:05:47 [main] DEBUG (MqttTraceCallback.java:20) -  TRANS MQTT-TRACE: MqttConnection, Connecting {ssl://mqtt-dia-stg.cpggpc.ca:1883} as {15283521401298}
transaction_event_15283521401298.txt:2016-10-27 17:05:47 [main] DEBUG (MqttTraceCallback.java:20) -  TRANS MQTT-TRACE: MqttConnection, myClient != null and the client is connecting. Connect return directly.
transaction_event_15283521401298.txt:2016-10-27 17:07:49 [main] DEBUG (MqttTraceCallback.java:20) -  TRANS MQTT-TRACE: MqttConnection, Connecting {ssl://mqtt-dia-stg.cpggpc.ca:1883} as {15283521401298}
transaction_event_15283521401298.txt:2016-10-27 17:07:49 [main] DEBUG (MqttTraceCallback.java:20) -  TRANS MQTT-TRACE: MqttConnection, myClient != null and the client is connecting. Connect return directly.
....
````
The fix is to clear connecting flag when an exception is caught in ````connect()```` method.


