### PR TITLE
Remove unnecessary `throws` declarations

### DIFF
--- a/org.eclipse.paho.android.sample/src/main/java/org/eclipse/paho/android/sample/activity/ActionListener.java
+++ b/org.eclipse.paho.android.sample/src/main/java/org/eclipse/paho/android/sample/activity/ActionListener.java
@@ -170,17 +170,12 @@ public class ActionListener implements IMqttActionListener {
         c.changeConnectionStatus(Connection.ConnectionStatus.CONNECTED);
         c.addAction("Client Connected");
         Log.i(TAG, c.handle() + " connected.");
-        try {
 
-            ArrayList<Subscription> subscriptions = connection.getSubscriptions();
-            for (Subscription sub : subscriptions) {
-                Log.i(TAG, "Auto-subscribing to: " + sub.getTopic() + "@ QoS: " + sub.getQos());
-                connection.getClient().subscribe(sub.getTopic(), sub.getQos());
-            }
-        } catch (MqttException ex){
-            Log.e(TAG, "Failed to Auto-Subscribe: " + ex.getMessage());
+        ArrayList<Subscription> subscriptions = connection.getSubscriptions();
+        for (Subscription sub : subscriptions) {
+            Log.i(TAG, "Auto-subscribing to: " + sub.getTopic() + "@ QoS: " + sub.getQos());
+            connection.getClient().subscribe(sub.getTopic(), sub.getQos());
         }
-
     }
 
     /**

--- a/org.eclipse.paho.android.sample/src/main/java/org/eclipse/paho/android/sample/activity/MainActivity.java
+++ b/org.eclipse.paho.android.sample/src/main/java/org/eclipse/paho/android/sample/activity/MainActivity.java
@@ -169,41 +169,36 @@ public class MainActivity extends AppCompatActivity implements FragmentDrawer.Fr
                 .getConnections();
 
         Log.i(TAG, "Updating connection: " + connections.keySet().toString());
-        try {
-            Connection connection = connections.get(model.getClientHandle());
-            // First disconnect the current instance of this connection
-            if(connection.isConnected()){
-                connection.changeConnectionStatus(Connection.ConnectionStatus.DISCONNECTING);
-                connection.getClient().disconnect();
-            }
-            // Update the connection.
-            connection.updateConnection(model.getClientId(), model.getServerHostName(), model.getServerPort(), model.isTlsConnection());
-            connection.changeConnectionStatus(Connection.ConnectionStatus.CONNECTING);
 
-            String[] actionArgs = new String[1];
-            actionArgs[0] = model.getClientId();
-            final ActionListener callback = new ActionListener(this,
-                    ActionListener.Action.CONNECT, connection, actionArgs);
-            connection.getClient().setCallback(new MqttCallbackHandler(this, model.getClientHandle()));
-
-            connection.getClient().setTraceCallback(new MqttTraceCallback());
-            MqttConnectOptions connOpts = optionsFromModel(model);
-            connection.addConnectionOptions(connOpts);
-            Connections.getInstance(this).updateConnection(connection);
-            drawerFragment.updateConnection(connection);
-
-            connection.getClient().connect(connOpts, null, callback);
-            Fragment fragment  = new ConnectionFragment();
-            Bundle bundle = new Bundle();
-            bundle.putString(ActivityConstants.CONNECTION_KEY, connection.handle());
-            fragment.setArguments(bundle);
-            String title = connection.getId();
-            displayFragment(fragment, title);
-
-
-        } catch (MqttException ex){
-            Log.e(TAG, "Exception occurred updating connection: " + connections.keySet().toString() + " : " + ex.getMessage());
+        Connection connection = connections.get(model.getClientHandle());
+        // First disconnect the current instance of this connection
+        if(connection.isConnected()){
+            connection.changeConnectionStatus(Connection.ConnectionStatus.DISCONNECTING);
+            connection.getClient().disconnect();
         }
+        // Update the connection.
+        connection.updateConnection(model.getClientId(), model.getServerHostName(), model.getServerPort(), model.isTlsConnection());
+        connection.changeConnectionStatus(Connection.ConnectionStatus.CONNECTING);
+
+        String[] actionArgs = new String[1];
+        actionArgs[0] = model.getClientId();
+        final ActionListener callback = new ActionListener(this,
+                ActionListener.Action.CONNECT, connection, actionArgs);
+        connection.getClient().setCallback(new MqttCallbackHandler(this, model.getClientHandle()));
+
+        connection.getClient().setTraceCallback(new MqttTraceCallback());
+        MqttConnectOptions connOpts = optionsFromModel(model);
+        connection.addConnectionOptions(connOpts);
+        Connections.getInstance(this).updateConnection(connection);
+        drawerFragment.updateConnection(connection);
+
+        connection.getClient().connect(connOpts, null, callback);
+        Fragment fragment  = new ConnectionFragment();
+        Bundle bundle = new Bundle();
+        bundle.putString(ActivityConstants.CONNECTION_KEY, connection.handle());
+        fragment.setArguments(bundle);
+        String title = connection.getId();
+        displayFragment(fragment, title);
     }
 
 
@@ -236,22 +231,14 @@ public class MainActivity extends AppCompatActivity implements FragmentDrawer.Fr
         connectionMap.add(model.getClientHandle());
         drawerFragment.addConnection(connection);
 
-        try {
-            connection.getClient().connect(connOpts, null, callback);
-            Fragment fragment  = new ConnectionFragment();
-            Bundle bundle = new Bundle();
-            bundle.putString(ActivityConstants.CONNECTION_KEY, connection.handle());
-            bundle.putBoolean(ActivityConstants.CONNECTED, true);
-            fragment.setArguments(bundle);
-            String title = connection.getId();
-            displayFragment(fragment, title);
-
-        }
-        catch (MqttException e) {
-            Log.e(this.getClass().getCanonicalName(),
-                    "MqttException occurred", e);
-        }
-
+        connection.getClient().connect(connOpts, null, callback);
+        Fragment fragment  = new ConnectionFragment();
+        Bundle bundle = new Bundle();
+        bundle.putString(ActivityConstants.CONNECTION_KEY, connection.handle());
+        bundle.putBoolean(ActivityConstants.CONNECTED, true);
+        fragment.setArguments(bundle);
+        String title = connection.getId();
+        displayFragment(fragment, title);
     }
 
 
@@ -290,36 +277,20 @@ public class MainActivity extends AppCompatActivity implements FragmentDrawer.Fr
         final ActionListener callback = new ActionListener(this,
                 ActionListener.Action.CONNECT, connection, actionArgs);
         connection.getClient().setCallback(new MqttCallbackHandler(this, connection.handle()));
-        try {
-            connection.getClient().connect(connection.getConnectionOptions(), null, callback);
-        }
-        catch (MqttException e) {
-            Log.e(this.getClass().getCanonicalName(),
-                    "MqttException occurred", e);
-        }
+        connection.getClient().connect(connection.getConnectionOptions(), null, callback);
     }
 
     public void disconnect(Connection connection){
-
-        try {
-            connection.getClient().disconnect();
-        } catch( MqttException ex){
-            Log.e(TAG, "Exception occurred during disconnect: " + ex.getMessage());
-        }
+        connection.getClient().disconnect();
     }
 
     public void publish(Connection connection, String topic, String message, int qos, boolean retain){
-
-        try {
-            String[] actionArgs = new String[2];
-            actionArgs[0] = message;
-            actionArgs[1] = topic;
-            final ActionListener callback = new ActionListener(this,
-                    ActionListener.Action.PUBLISH, connection, actionArgs);
-            connection.getClient().publish(topic, message.getBytes(), qos, retain, null, callback);
-        } catch( MqttException ex){
-            Log.e(TAG, "Exception occurred during publish: " + ex.getMessage());
-        }
+        String[] actionArgs = new String[2];
+        actionArgs[0] = message;
+        actionArgs[1] = topic;
+        final ActionListener callback = new ActionListener(this,
+                ActionListener.Action.PUBLISH, connection, actionArgs);
+        connection.getClient().publish(topic, message.getBytes(), qos, retain, null, callback);
     }
 
     /**

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
@@ -283,7 +283,6 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * Close the client. Releases all resource associated with the client. After
 	 * the client has been closed it cannot be reused. For instance attempts to
 	 * connect will fail.
-	 *
 	 */
 	@Override
 	public void close() {
@@ -303,15 +302,13 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * The default options are specified in {@link MqttConnectOptions} class.
 	 * </p>
 	 * 
-	 * @throws MqttException
-	 *             for any connected problems
 	 * @return token used to track and wait for the connect to complete. The
 	 *         token will be passed to the callback methods if a callback is
 	 *         set.
 	 * @see #connect(MqttConnectOptions, Object, IMqttActionListener)
 	 */
 	@Override
-	public IMqttToken connect() throws MqttException {
+	public IMqttToken connect() {
 		return connect(null, null);
 	}
 
@@ -325,14 +322,12 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * 
 	 * @param options
 	 *            a set of connection parameters that override the defaults.
-	 * @throws MqttException
-	 *             for any connected problems
 	 * @return token used to track and wait for the connect to complete. The
 	 *         token will be passed to any callback that has been set.
 	 * @see #connect(MqttConnectOptions, Object, IMqttActionListener)
 	 */
 	@Override
-	public IMqttToken connect(MqttConnectOptions options) throws MqttException {
+	public IMqttToken connect(MqttConnectOptions options) {
 		return connect(options, null, null);
 	}
 
@@ -348,15 +343,12 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * @param callback
 	 *            optional listener that will be notified when the connect
 	 *            completes. Use null if not required.
-	 * @throws MqttException
-	 *             for any connected problems
 	 * @return token used to track and wait for the connect to complete. The
 	 *         token will be passed to any callback that has been set.
 	 * @see #connect(MqttConnectOptions, Object, IMqttActionListener)
 	 */
 	@Override
-	public IMqttToken connect(Object userContext, IMqttActionListener callback)
-			throws MqttException {
+	public IMqttToken connect(Object userContext, IMqttActionListener callback) {
 		return connect(new MqttConnectOptions(), userContext, callback);
 	}
 
@@ -390,13 +382,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            completes. Use null if not required.
 	 * @return token used to track and wait for the connect to complete. The
 	 *         token will be passed to any callback that has been set.
-	 * @throws MqttException
-	 *             for any connected problems, including communication errors
 	 */
 
 	@Override
 	public IMqttToken connect(MqttConnectOptions options, Object userContext,
-			IMqttActionListener callback) throws MqttException {
+			IMqttActionListener callback) {
 
 		IMqttToken token = new MqttTokenAndroid(this, userContext,
 				callback);
@@ -488,12 +478,10 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * 
 	 * @return token used to track and wait for disconnect to complete. The
 	 *         token will be passed to any callback that has been set.
-	 * @throws MqttException
-	 *             for problems encountered while disconnecting
 	 * @see #disconnect(long, Object, IMqttActionListener)
 	 */
 	@Override
-	public IMqttToken disconnect() throws MqttException {
+	public IMqttToken disconnect() {
 		IMqttToken token = new MqttTokenAndroid(this, null,
 				null);
 		String activityToken = storeToken(token);
@@ -517,12 +505,10 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * @return token used to track and wait for disconnect to complete. The
 	 *         token will be passed to the callback methods if a callback is
 	 *         set.
-	 * @throws MqttException
-	 *             for problems encountered while disconnecting
 	 * @see #disconnect(long, Object, IMqttActionListener)
 	 */
 	@Override
-	public IMqttToken disconnect(long quiesceTimeout) throws MqttException {
+	public IMqttToken disconnect(long quiesceTimeout) {
 		IMqttToken token = new MqttTokenAndroid(this, null,
 				null);
 		String activityToken = storeToken(token);
@@ -548,13 +534,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            completes. Use null if not required.
 	 * @return token used to track and wait for the disconnect to complete. The
 	 *         token will be passed to any callback that has been set.
-	 * @throws MqttException
-	 *             for problems encountered while disconnecting
 	 * @see #disconnect(long, Object, IMqttActionListener)
 	 */
 	@Override
 	public IMqttToken disconnect(Object userContext,
-			IMqttActionListener callback) throws MqttException {
+			IMqttActionListener callback) {
 		IMqttToken token = new MqttTokenAndroid(this, userContext,
 				callback);
 		String activityToken = storeToken(token);
@@ -602,12 +586,10 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            completes. Use null if not required.
 	 * @return token used to track and wait for the disconnect to complete. The
 	 *         token will be passed to any callback that has been set.
-	 * @throws MqttException
-	 *             for problems encountered while disconnecting
 	 */
 	@Override
 	public IMqttToken disconnect(long quiesceTimeout, Object userContext,
-			IMqttActionListener callback) throws MqttException {
+			IMqttActionListener callback) {
 		IMqttToken token = new MqttTokenAndroid(this, userContext,
 				callback);
 		String activityToken = storeToken(token);
@@ -634,18 +616,13 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            whether or not this message should be retained by the server.
 	 * @return token used to track and wait for the publish to complete. The
 	 *         token will be passed to any callback that has been set.
-	 * @throws MqttPersistenceException
-	 *             when a problem occurs storing the message
 	 * @throws IllegalArgumentException
 	 *             if value of QoS is not 0, 1 or 2.
-	 * @throws MqttException
-	 *             for other errors encountered while publishing the message.
-	 *             For instance, too many messages are being processed.
 	 * @see #publish(String, MqttMessage, Object, IMqttActionListener)
 	 */
 	@Override
 	public IMqttDeliveryToken publish(String topic, byte[] payload, int qos,
-			boolean retained) throws MqttException, MqttPersistenceException {
+			boolean retained) {
 		return publish(topic, payload, qos, retained, null, null);
 	}
 
@@ -660,18 +637,12 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            to deliver to the server
 	 * @return token used to track and wait for the publish to complete. The
 	 *         token will be passed to any callback that has been set.
-	 * @throws MqttPersistenceException
-	 *             when a problem occurs storing the message
 	 * @throws IllegalArgumentException
 	 *             if value of QoS is not 0, 1 or 2.
-	 * @throws MqttException
-	 *             for other errors encountered while publishing the message.
-	 *             For instance client not connected.
 	 * @see #publish(String, MqttMessage, Object, IMqttActionListener)
 	 */
 	@Override
-	public IMqttDeliveryToken publish(String topic, MqttMessage message)
-			throws MqttException, MqttPersistenceException {
+	public IMqttDeliveryToken publish(String topic, MqttMessage message) {
 		return publish(topic, message, null, null);
 	}
 
@@ -699,19 +670,13 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            has completed to the requested quality of service
 	 * @return token used to track and wait for the publish to complete. The
 	 *         token will be passed to any callback that has been set.
-	 * @throws MqttPersistenceException
-	 *             when a problem occurs storing the message
 	 * @throws IllegalArgumentException
 	 *             if value of QoS is not 0, 1 or 2.
-	 * @throws MqttException
-	 *             for other errors encountered while publishing the message.
-	 *             For instance client not connected.
 	 * @see #publish(String, MqttMessage, Object, IMqttActionListener)
 	 */
 	@Override
 	public IMqttDeliveryToken publish(String topic, byte[] payload, int qos,
-			boolean retained, Object userContext, IMqttActionListener callback)
-			throws MqttException, MqttPersistenceException {
+			boolean retained, Object userContext, IMqttActionListener callback) {
 
 		MqttMessage message = new MqttMessage(payload);
 		message.setQos(qos);
@@ -798,19 +763,13 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            has completed to the requested quality of service
 	 * @return token used to track and wait for the publish to complete. The
 	 *         token will be passed to callback methods if set.
-	 * @throws MqttPersistenceException
-	 *             when a problem occurs storing the message
 	 * @throws IllegalArgumentException
 	 *             if value of QoS is not 0, 1 or 2.
-	 * @throws MqttException
-	 *             for other errors encountered while publishing the message.
-	 *             For instance, client not connected.
 	 * @see MqttMessage
 	 */
 	@Override
 	public IMqttDeliveryToken publish(String topic, MqttMessage message,
-			Object userContext, IMqttActionListener callback)
-			throws MqttException, MqttPersistenceException {
+			Object userContext, IMqttActionListener callback) {
 		MqttDeliveryTokenAndroid token = new MqttDeliveryTokenAndroid(
 				this, userContext, callback, message);
 		String activityToken = storeToken(token);
@@ -833,16 +792,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            subscription.
 	 * @return token used to track and wait for the subscribe to complete. The
 	 *         token will be passed to callback methods if set.
-	 * @throws MqttSecurityException
-	 *             for security related problems
-	 * @throws MqttException
-	 *             for non security related problems
-	 * 
+	 *
 	 * @see #subscribe(String[], int[], Object, IMqttActionListener)
 	 */
 	@Override
-	public IMqttToken subscribe(String topic, int qos) throws MqttException,
-			MqttSecurityException {
+	public IMqttToken subscribe(String topic, int qos) {
 		return subscribe(topic, qos, null, null);
 	}
 
@@ -865,16 +819,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            subscription.
 	 * @return token used to track and wait for the subscription to complete. The
 	 *         token will be passed to callback methods if set.
-	 * @throws MqttSecurityException
-	 *             for security related problems
-	 * @throws MqttException
-	 *             for non security related problems
-	 * 
+	 *
 	 * @see #subscribe(String[], int[], Object, IMqttActionListener)
 	 */
 	@Override
-	public IMqttToken subscribe(String[] topic, int[] qos)
-			throws MqttException, MqttSecurityException {
+	public IMqttToken subscribe(String[] topic, int[] qos) {
 		return subscribe(topic, qos, null, null);
 	}
 
@@ -897,14 +846,12 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            completed
 	 * @return token used to track and wait for the subscribe to complete. The
 	 *         token will be passed to callback methods if set.
-	 * @throws MqttException
-	 *             if there was an error when registering the subscription.
-	 * 
+	 *
 	 * @see #subscribe(String[], int[], Object, IMqttActionListener)
 	 */
 	@Override
 	public IMqttToken subscribe(String topic, int qos, Object userContext,
-			IMqttActionListener callback) throws MqttException {
+			IMqttActionListener callback) {
 		IMqttToken token = new MqttTokenAndroid(this, userContext,
 				callback, new String[]{topic});
 		String activityToken = storeToken(token);
@@ -1037,14 +984,12 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            completed
 	 * @return token used to track and wait for the subscribe to complete. The
 	 *         token will be passed to callback methods if set.
-	 * @throws MqttException
-	 *             if there was an error registering the subscription.
 	 * @throws IllegalArgumentException
 	 *             if the two supplied arrays are not the same size.
 	 */
 	@Override
 	public IMqttToken subscribe(String[] topic, int[] qos, Object userContext,
-			IMqttActionListener callback) throws MqttException {
+			IMqttActionListener callback) {
 		IMqttToken token = new MqttTokenAndroid(this, userContext,
 				callback, topic);
 		String activityToken = storeToken(token);
@@ -1069,9 +1014,8 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * @param messageListener a callback to handle incoming messages
 	 * @return token used to track and wait for the subscribe to complete. The token
 	 * will be passed to callback methods if set.
-	 * @throws MqttException if there was an error registering the subscription.
 	 */
-	public IMqttToken subscribe(String topicFilter, int qos, Object userContext, IMqttActionListener callback, IMqttMessageListener messageListener) throws MqttException {
+	public IMqttToken subscribe(String topicFilter, int qos, Object userContext, IMqttActionListener callback, IMqttMessageListener messageListener) {
 
 		return subscribe(new String[] {topicFilter}, new int[] {qos}, userContext, callback, new IMqttMessageListener[] {messageListener});
 	}
@@ -1089,9 +1033,8 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * @param messageListener a callback to handle incoming messages
 	 * @return token used to track and wait for the subscribe to complete. The token
 	 * will be passed to callback methods if set.
-	 * @throws MqttException if there was an error registering the subscription.
 	 */
-	public IMqttToken subscribe(String topicFilter, int qos, IMqttMessageListener messageListener) throws MqttException {
+	public IMqttToken subscribe(String topicFilter, int qos, IMqttMessageListener messageListener) {
 		
 		return subscribe(topicFilter, qos, null, null, messageListener);
 	}
@@ -1113,9 +1056,8 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * @param messageListeners an array of callbacks to handle incoming messages
 	 * @return token used to track and wait for the subscribe to complete. The token
 	 * will be passed to callback methods if set.
-	 * @throws MqttException if there was an error registering the subscription.
 	 */
-	public IMqttToken subscribe(String[] topicFilters, int[] qos, IMqttMessageListener[] messageListeners) throws MqttException {
+	public IMqttToken subscribe(String[] topicFilters, int[] qos, IMqttMessageListener[] messageListeners) {
 		
 		return subscribe(topicFilters, qos, null, null, messageListeners);
 	}
@@ -1141,9 +1083,8 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * @param messageListeners an array of callbacks to handle incoming messages
 	 * @return token used to track and wait for the subscribe to complete. The token
 	 * will be passed to callback methods if set.
-	 * @throws MqttException if there was an error registering the subscription.
 	 */
-	public IMqttToken subscribe(String[] topicFilters, int[] qos, Object userContext, IMqttActionListener callback, IMqttMessageListener[] messageListeners) throws MqttException {
+	public IMqttToken subscribe(String[] topicFilters, int[] qos, Object userContext, IMqttActionListener callback, IMqttMessageListener[] messageListeners) {
 		IMqttToken token = new MqttTokenAndroid(this, userContext, callback, topicFilters);
 		String activityToken = storeToken(token);
 		mqttService.subscribe(clientHandle, topicFilters, qos, null, activityToken, messageListeners);
@@ -1160,13 +1101,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            on an earlier subscribe.
 	 * @return token used to track and wait for the unsubscribe to complete. The
 	 *         token will be passed to callback methods if set.
-	 * @throws MqttException
-	 *             if there was an error unregistering the subscription.
-	 * 
+	 *
 	 * @see #unsubscribe(String[], Object, IMqttActionListener)
 	 */
 	@Override
-	public IMqttToken unsubscribe(String topic) throws MqttException {
+	public IMqttToken unsubscribe(String topic) {
 		return unsubscribe(topic, null, null);
 	}
 
@@ -1178,13 +1117,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            one specified on an earlier subscription.
 	 * @return token used to track and wait for the unsubscribe to complete. The
 	 *         token will be passed to callback methods if set.
-	 * @throws MqttException
-	 *             if there was an error unregistering the subscription.
-	 * 
+	 *
 	 * @see #unsubscribe(String[], Object, IMqttActionListener)
 	 */
 	@Override
-	public IMqttToken unsubscribe(String[] topic) throws MqttException {
+	public IMqttToken unsubscribe(String[] topic) {
 		return unsubscribe(topic, null, null);
 	}
 
@@ -1202,14 +1139,12 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            completed
 	 * @return token used to track and wait for the unsubscribe to complete. The
 	 *         token will be passed to callback methods if set.
-	 * @throws MqttException
-	 *             if there was an error unregistering the subscription.
-	 * 
+	 *
 	 * @see #unsubscribe(String[], Object, IMqttActionListener)
 	 */
 	@Override
 	public IMqttToken unsubscribe(String topic, Object userContext,
-			IMqttActionListener callback) throws MqttException {
+			IMqttActionListener callback) {
 		IMqttToken token = new MqttTokenAndroid(this, userContext,
 				callback);
 		String activityToken = storeToken(token);
@@ -1251,12 +1186,10 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 *            completed
 	 * @return token used to track and wait for the unsubscribe to complete. The
 	 *         token will be passed to callback methods if set.
-	 * @throws MqttException
-	 *             if there was an error unregistering the subscription.
 	 */
 	@Override
 	public IMqttToken unsubscribe(String[] topic, Object userContext,
-			IMqttActionListener callback) throws MqttException {
+			IMqttActionListener callback) {
 		IMqttToken token = new MqttTokenAndroid(this, userContext,
 				callback);
 		String activityToken = storeToken(token);

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttService.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttService.java
@@ -431,14 +431,11 @@ public class MqttService extends Service implements MqttTraceHandler {
    *            arbitrary data to be passed back to the application
    * @param activityToken
    *            arbitrary identifier to be passed back to the Activity
-   * @throws MqttPersistenceException when a problem occurs storing the message
-   * @throws MqttException if there was an error publishing the message
    * @return token for tracking the operation
    */
   public IMqttDeliveryToken publish(String clientHandle, String topic,
       byte[] payload, int qos, boolean retained,
-      String invocationContext, String activityToken)
-      throws MqttPersistenceException, MqttException {
+      String invocationContext, String activityToken) {
     MqttConnection client = getConnection(clientHandle);
     return client.publish(topic, payload, qos, retained, invocationContext,
         activityToken);
@@ -457,13 +454,10 @@ public class MqttService extends Service implements MqttTraceHandler {
    *            arbitrary data to be passed back to the application
    * @param activityToken
    *            arbitrary identifier to be passed back to the Activity
-   * @throws MqttPersistenceException when a problem occurs storing the message
-   * @throws MqttException if there was an error publishing the message
    * @return token for tracking the operation
    */
   public IMqttDeliveryToken publish(String clientHandle, String topic,
-      MqttMessage message, String invocationContext, String activityToken)
-      throws MqttPersistenceException, MqttException {
+      MqttMessage message, String invocationContext, String activityToken) {
     MqttConnection client = getConnection(clientHandle);
     return client.publish(topic, message, invocationContext, activityToken);
   }

--- a/paho.mqtt.android.example/src/main/java/paho/mqtt/java/example/PahoExampleActivity.java
+++ b/paho.mqtt.android.example/src/main/java/paho/mqtt/java/example/PahoExampleActivity.java
@@ -113,32 +113,24 @@ public class PahoExampleActivity extends AppCompatActivity{
 
 
 
+        //addToHistory("Connecting to " + serverUri);
+        mqttAndroidClient.connect(mqttConnectOptions, null, new IMqttActionListener() {
+            @Override
+            public void onSuccess(IMqttToken asyncActionToken) {
+                DisconnectedBufferOptions disconnectedBufferOptions = new DisconnectedBufferOptions();
+                disconnectedBufferOptions.setBufferEnabled(true);
+                disconnectedBufferOptions.setBufferSize(100);
+                disconnectedBufferOptions.setPersistBuffer(false);
+                disconnectedBufferOptions.setDeleteOldestMessages(false);
+                mqttAndroidClient.setBufferOpts(disconnectedBufferOptions);
+                subscribeToTopic();
+            }
 
-        try {
-            //addToHistory("Connecting to " + serverUri);
-            mqttAndroidClient.connect(mqttConnectOptions, null, new IMqttActionListener() {
-                @Override
-                public void onSuccess(IMqttToken asyncActionToken) {
-                    DisconnectedBufferOptions disconnectedBufferOptions = new DisconnectedBufferOptions();
-                    disconnectedBufferOptions.setBufferEnabled(true);
-                    disconnectedBufferOptions.setBufferSize(100);
-                    disconnectedBufferOptions.setPersistBuffer(false);
-                    disconnectedBufferOptions.setDeleteOldestMessages(false);
-                    mqttAndroidClient.setBufferOpts(disconnectedBufferOptions);
-                    subscribeToTopic();
-                }
-
-                @Override
-                public void onFailure(IMqttToken asyncActionToken, Throwable exception) {
-                    addToHistory("Failed to connect to: " + serverUri);
-                }
-            });
-
-
-        } catch (MqttException ex){
-            ex.printStackTrace();
-        }
-
+            @Override
+            public void onFailure(IMqttToken asyncActionToken, Throwable exception) {
+                addToHistory("Failed to connect to: " + serverUri);
+            }
+        });
     }
 
     private void addToHistory(String mainText){
@@ -169,48 +161,35 @@ public class PahoExampleActivity extends AppCompatActivity{
     }
 
     public void subscribeToTopic(){
-        try {
-            mqttAndroidClient.subscribe(subscriptionTopic, 0, null, new IMqttActionListener() {
-                @Override
-                public void onSuccess(IMqttToken asyncActionToken) {
-                    addToHistory("Subscribed!");
-                }
+        mqttAndroidClient.subscribe(subscriptionTopic, 0, null, new IMqttActionListener() {
+            @Override
+            public void onSuccess(IMqttToken asyncActionToken) {
+                addToHistory("Subscribed!");
+            }
 
-                @Override
-                public void onFailure(IMqttToken asyncActionToken, Throwable exception) {
-                    addToHistory("Failed to subscribe");
-                }
-            });
+            @Override
+            public void onFailure(IMqttToken asyncActionToken, Throwable exception) {
+                addToHistory("Failed to subscribe");
+            }
+        });
 
-            // THIS DOES NOT WORK!
-            mqttAndroidClient.subscribe(subscriptionTopic, 0, new IMqttMessageListener() {
-                @Override
-                public void messageArrived(String topic, MqttMessage message) throws Exception {
-                    // message Arrived!
-                    System.out.println("Message: " + topic + " : " + new String(message.getPayload()));
-                }
-            });
-
-        } catch (MqttException ex){
-            System.err.println("Exception whilst subscribing");
-            ex.printStackTrace();
-        }
+        // THIS DOES NOT WORK!
+        mqttAndroidClient.subscribe(subscriptionTopic, 0, new IMqttMessageListener() {
+            @Override
+            public void messageArrived(String topic, MqttMessage message) throws Exception {
+                // message Arrived!
+                System.out.println("Message: " + topic + " : " + new String(message.getPayload()));
+            }
+        });
     }
 
     public void publishMessage(){
-
-        try {
-            MqttMessage message = new MqttMessage();
-            message.setPayload(publishMessage.getBytes());
-            mqttAndroidClient.publish(publishTopic, message);
-            addToHistory("Message Published");
-            if(!mqttAndroidClient.isConnected()){
-                addToHistory(mqttAndroidClient.getBufferedMessageCount() + " messages in buffer.");
-            }
-        } catch (MqttException e) {
-            System.err.println("Error Publishing: " + e.getMessage());
-            e.printStackTrace();
+        MqttMessage message = new MqttMessage();
+        message.setPayload(publishMessage.getBytes());
+        mqttAndroidClient.publish(publishTopic, message);
+        addToHistory("Message Published");
+        if(!mqttAndroidClient.isConnected()){
+            addToHistory(mqttAndroidClient.getBufferedMessageCount() + " messages in buffer.");
         }
     }
-
 }


### PR DESCRIPTION
The android client is completely asynchronous, which means
most methods will never throw anything, and errors must be handled
on callbacks instead.

Now, handling errors on asynchronous code is hard enough.
Having to insert `try-catch` blocks on things that never fail only makes it worse.
Therefore This patch removes `throws` declarations where they are not needed.

---
Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
