### PR TITLE
Delegate original token when calling (dis)connect and (un)subscribe

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
@@ -454,8 +454,9 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 		
 		String activityToken = storeToken(connectToken);
 		try {
-			mqttService.connect(clientHandle, connectOptions, null,
+			IMqttToken internalToken = mqttService.connect(clientHandle, connectOptions, null,
 					activityToken);
+			((MqttTokenAndroid)connectToken).setDelegate(internalToken);
 		}
 		catch (MqttException e) {
 			IMqttActionListener listener = connectToken.getActionCallback();
@@ -480,10 +481,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 */
 	@Override
 	public IMqttToken disconnect() {
-		IMqttToken token = new MqttTokenAndroid(this, null,
+		MqttTokenAndroid token = new MqttTokenAndroid(this, null,
 				null);
 		String activityToken = storeToken(token);
-		mqttService.disconnect(clientHandle, null, activityToken);
+		IMqttToken internalToken = mqttService.disconnect(clientHandle, null, activityToken);
+		token.setDelegate(internalToken);
 		return token;
 	}
 
@@ -507,11 +509,12 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 */
 	@Override
 	public IMqttToken disconnect(long quiesceTimeout) {
-		IMqttToken token = new MqttTokenAndroid(this, null,
+		MqttTokenAndroid token = new MqttTokenAndroid(this, null,
 				null);
 		String activityToken = storeToken(token);
-		mqttService.disconnect(clientHandle, quiesceTimeout, null,
+		IMqttToken internalToken = mqttService.disconnect(clientHandle, quiesceTimeout, null,
 				activityToken);
+		token.setDelegate(internalToken);
 		return token;
 	}
 
@@ -537,10 +540,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	@Override
 	public IMqttToken disconnect(Object userContext,
 			IMqttActionListener callback) {
-		IMqttToken token = new MqttTokenAndroid(this, userContext,
+		MqttTokenAndroid token = new MqttTokenAndroid(this, userContext,
 				callback);
 		String activityToken = storeToken(token);
-		mqttService.disconnect(clientHandle, null, activityToken);
+		IMqttToken internalToken = mqttService.disconnect(clientHandle, null, activityToken);
+		token.setDelegate(internalToken);
 		return token;
 	}
 
@@ -588,11 +592,12 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	@Override
 	public IMqttToken disconnect(long quiesceTimeout, Object userContext,
 			IMqttActionListener callback) {
-		IMqttToken token = new MqttTokenAndroid(this, userContext,
+		MqttTokenAndroid token = new MqttTokenAndroid(this, userContext,
 				callback);
 		String activityToken = storeToken(token);
-		mqttService.disconnect(clientHandle, quiesceTimeout, null,
+		IMqttToken internalToken = mqttService.disconnect(clientHandle, quiesceTimeout, null,
 				activityToken);
+		token.setDelegate(internalToken);
 		return token;
 	}
 
@@ -850,10 +855,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	@Override
 	public IMqttToken subscribe(String topic, int qos, Object userContext,
 			IMqttActionListener callback) {
-		IMqttToken token = new MqttTokenAndroid(this, userContext,
+		MqttTokenAndroid token = new MqttTokenAndroid(this, userContext,
 				callback, new String[]{topic});
 		String activityToken = storeToken(token);
-		mqttService.subscribe(clientHandle, topic, qos, null, activityToken);
+		IMqttToken internalToken = mqttService.subscribe(clientHandle, topic, qos, null, activityToken);
+		token.setDelegate(internalToken);
 		return token;
 	}
 
@@ -988,10 +994,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	@Override
 	public IMqttToken subscribe(String[] topic, int[] qos, Object userContext,
 			IMqttActionListener callback) {
-		IMqttToken token = new MqttTokenAndroid(this, userContext,
+		MqttTokenAndroid token = new MqttTokenAndroid(this, userContext,
 				callback, topic);
 		String activityToken = storeToken(token);
-		mqttService.subscribe(clientHandle, topic, qos, null, activityToken);
+		IMqttToken internalToken = mqttService.subscribe(clientHandle, topic, qos, null, activityToken);
+		token.setDelegate(internalToken);
 		return token;
 	}
 	
@@ -1083,9 +1090,10 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 * will be passed to callback methods if set.
 	 */
 	public IMqttToken subscribe(String[] topicFilters, int[] qos, Object userContext, IMqttActionListener callback, IMqttMessageListener[] messageListeners) {
-		IMqttToken token = new MqttTokenAndroid(this, userContext, callback, topicFilters);
+		MqttTokenAndroid token = new MqttTokenAndroid(this, userContext, callback, topicFilters);
 		String activityToken = storeToken(token);
-		mqttService.subscribe(clientHandle, topicFilters, qos, null, activityToken, messageListeners);
+		IMqttToken internalToken = mqttService.subscribe(clientHandle, topicFilters, qos, null, activityToken, messageListeners);
+		token.setDelegate(internalToken);
 
 		return null;
 	}
@@ -1143,10 +1151,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	@Override
 	public IMqttToken unsubscribe(String topic, Object userContext,
 			IMqttActionListener callback) {
-		IMqttToken token = new MqttTokenAndroid(this, userContext,
+		MqttTokenAndroid token = new MqttTokenAndroid(this, userContext,
 				callback);
 		String activityToken = storeToken(token);
-		mqttService.unsubscribe(clientHandle, topic, null, activityToken);
+		IMqttToken internalToken = mqttService.unsubscribe(clientHandle, topic, null, activityToken);
+		token.setDelegate(internalToken);
 		return token;
 	}
 
@@ -1188,10 +1197,11 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	@Override
 	public IMqttToken unsubscribe(String[] topic, Object userContext,
 			IMqttActionListener callback) {
-		IMqttToken token = new MqttTokenAndroid(this, userContext,
+		MqttTokenAndroid token = new MqttTokenAndroid(this, userContext,
 				callback);
 		String activityToken = storeToken(token);
-		mqttService.unsubscribe(clientHandle, topic, null, activityToken);
+		IMqttToken internalToken = mqttService.unsubscribe(clientHandle, topic, null, activityToken);
+		token.setDelegate(internalToken);
 		return token;
 	}
 

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
@@ -186,8 +186,9 @@ class MqttConnection implements MqttCallbackExtended {
 	 *            arbitrary data to be passed back to the application
 	 * @param activityToken
 	 *            arbitrary identifier to be passed back to the Activity
+	 * @return token for tracking the operation
 	 */
-	public void connect(MqttConnectOptions options, String invocationContext,
+	public IMqttToken connect(MqttConnectOptions options, String invocationContext,
 			String activityToken) {
 		
 		connectOptions = options;
@@ -212,7 +213,7 @@ class MqttConnection implements MqttCallbackExtended {
 		resultBundle.putString(MqttServiceConstants.CALLBACK_ACTION,
 				MqttServiceConstants.CONNECT_ACTION);
 		
-				
+		IMqttToken sendToken = null;
 		try {
 			if (persistence == null) {
 				// ask Android where we can put files
@@ -231,7 +232,7 @@ class MqttConnection implements MqttCallbackExtended {
 								MqttServiceConstants.CALLBACK_EXCEPTION, new MqttPersistenceException());
 						service.callbackToActivity(clientHandle, Status.ERROR,
 								resultBundle);
-						return;
+						return sendToken;
 					}
 				}
 
@@ -279,7 +280,7 @@ class MqttConnection implements MqttCallbackExtended {
 					service.traceDebug(TAG, "myClient != null and the client is not connected");
 					service.traceDebug(TAG,"Do Real connect!");
 					setConnectingState(true);
-					myClient.connect(connectOptions, invocationContext, listener);
+					sendToken = myClient.connect(connectOptions, invocationContext, listener);
 				}
 			}
 			
@@ -292,13 +293,14 @@ class MqttConnection implements MqttCallbackExtended {
 
 				service.traceDebug(TAG,"Do Real connect!");
 				setConnectingState(true);
-				myClient.connect(connectOptions, invocationContext, listener);
+				sendToken = myClient.connect(connectOptions, invocationContext, listener);
 			}
 		} catch (Exception e) {
 			service.traceError(TAG, "Exception occurred attempting to connect: " + e.getMessage());
 			setConnectingState(false);
 			handleException(resultBundle, e);
 		}
+		return sendToken;
 	}
 
 	private void doAfterConnectSuccess(final Bundle resultBundle) {
@@ -404,8 +406,9 @@ class MqttConnection implements MqttCallbackExtended {
 	 *            arbitrary data to be passed back to the application
 	 * @param activityToken
 	 *            arbitrary string to be passed back to the activity
+	 * @return token for tracking the operation
 	 */
-	void disconnect(long quiesceTimeout, String invocationContext,
+	IMqttToken disconnect(long quiesceTimeout, String invocationContext,
 			String activityToken) {
 		service.traceDebug(TAG, "disconnect()");
 		disconnected = true;
@@ -417,11 +420,13 @@ class MqttConnection implements MqttCallbackExtended {
 				invocationContext);
 		resultBundle.putString(MqttServiceConstants.CALLBACK_ACTION,
 				MqttServiceConstants.DISCONNECT_ACTION);
+
+		IMqttToken sendToken = null;
 		if ((myClient != null) && (myClient.isConnected())) {
 			IMqttActionListener listener = new MqttConnectionListener(
 					resultBundle);
 			try {
-				myClient.disconnect(quiesceTimeout, invocationContext, listener);
+				sendToken = myClient.disconnect(quiesceTimeout, invocationContext, listener);
 			} catch (Exception e) {
 				handleException(resultBundle, e);
 			}
@@ -437,8 +442,8 @@ class MqttConnection implements MqttCallbackExtended {
 			// assume we'll clear the stored messages at this point
 			service.messageStore.clearArrivedMessages(clientHandle);
 		}
-
 		releaseWakeLock();
+		return sendToken;
 	}
 
 	/**
@@ -448,8 +453,9 @@ class MqttConnection implements MqttCallbackExtended {
 	 *            arbitrary data to be passed back to the application
 	 * @param activityToken
 	 *            arbitrary string to be passed back to the activity
+	 * @return token for tracking the operation
 	 */
-	void disconnect(String invocationContext, String activityToken) {
+	IMqttToken disconnect(String invocationContext, String activityToken) {
 		service.traceDebug(TAG, "disconnect()");
 		disconnected = true;
 		final Bundle resultBundle = new Bundle();
@@ -460,11 +466,13 @@ class MqttConnection implements MqttCallbackExtended {
 				invocationContext);
 		resultBundle.putString(MqttServiceConstants.CALLBACK_ACTION,
 				MqttServiceConstants.DISCONNECT_ACTION);
+
+		IMqttToken sendToken = null;
 		if ((myClient != null) && (myClient.isConnected())) {
 			IMqttActionListener listener = new MqttConnectionListener(
 					resultBundle);
 			try {
-				myClient.disconnect(invocationContext, listener);
+				sendToken = myClient.disconnect(invocationContext, listener);
 			} catch (Exception e) {
 				handleException(resultBundle, e);
 			}
@@ -481,6 +489,7 @@ class MqttConnection implements MqttCallbackExtended {
 			service.messageStore.clearArrivedMessages(clientHandle);
 		}
 		releaseWakeLock();
+		return sendToken;
 	}
 
 	/**
@@ -520,7 +529,6 @@ class MqttConnection implements MqttCallbackExtended {
 				invocationContext);
 
 		IMqttDeliveryToken sendToken = null;
-
 		if ((myClient != null) && (myClient.isConnected())) {
 			IMqttActionListener listener = new MqttConnectionListener(
 					resultBundle);
@@ -616,8 +624,9 @@ class MqttConnection implements MqttCallbackExtended {
 	 *            arbitrary data to be passed back to the application
 	 * @param activityToken
 	 *            arbitrary identifier to be passed back to the Activity
+	 * @return token for tracking the operation
 	 */
-	public void subscribe(final String topic, final int qos,
+	public IMqttToken subscribe(final String topic, final int qos,
 			String invocationContext, String activityToken) {
 		service.traceDebug(TAG, "subscribe({" + topic + "}," + qos + ",{"
 				+ invocationContext + "}, {" + activityToken + "}");
@@ -630,11 +639,12 @@ class MqttConnection implements MqttCallbackExtended {
 				MqttServiceConstants.CALLBACK_INVOCATION_CONTEXT,
 				invocationContext);
 
+		IMqttToken sendToken = null;
 		if ((myClient != null) && (myClient.isConnected())) {
 			IMqttActionListener listener = new MqttConnectionListener(
 					resultBundle);
 			try {
-				myClient.subscribe(topic, qos, invocationContext, listener);
+				sendToken = myClient.subscribe(topic, qos, invocationContext, listener);
 			} catch (Exception e) {
 				handleException(resultBundle, e);
 			}
@@ -644,6 +654,7 @@ class MqttConnection implements MqttCallbackExtended {
 			service.traceError("subscribe", NOT_CONNECTED);
 			service.callbackToActivity(clientHandle, Status.ERROR, resultBundle);
 		}
+		return sendToken;
 	}
 
 	/**
@@ -657,8 +668,9 @@ class MqttConnection implements MqttCallbackExtended {
 	 *            arbitrary data to be passed back to the application
 	 * @param activityToken
 	 *            arbitrary identifier to be passed back to the Activity
+	 * @return token for tracking the operation
 	 */
-	public void subscribe(final String[] topic, final int[] qos,
+	public IMqttToken subscribe(final String[] topic, final int[] qos,
 			String invocationContext, String activityToken) {
 		service.traceDebug(TAG, "subscribe({" + Arrays.toString(topic) + "}," + Arrays.toString(qos) + ",{"
 				+ invocationContext + "}, {" + activityToken + "}");
@@ -671,11 +683,12 @@ class MqttConnection implements MqttCallbackExtended {
 				MqttServiceConstants.CALLBACK_INVOCATION_CONTEXT,
 				invocationContext);
 
+		IMqttToken sendToken = null;
 		if ((myClient != null) && (myClient.isConnected())) {
 			IMqttActionListener listener = new MqttConnectionListener(
 					resultBundle);
 			try {
-				myClient.subscribe(topic, qos, invocationContext, listener);
+				sendToken = myClient.subscribe(topic, qos, invocationContext, listener);
 			} catch (Exception e) {
 				handleException(resultBundle, e);
 			}
@@ -685,20 +698,22 @@ class MqttConnection implements MqttCallbackExtended {
 			service.traceError("subscribe", NOT_CONNECTED);
 			service.callbackToActivity(clientHandle, Status.ERROR, resultBundle);
 		}
+		return sendToken;
 	}
 
-	public void subscribe(String[] topicFilters, int[] qos, String invocationContext, String activityToken, IMqttMessageListener[] messageListeners) {
+	public IMqttToken subscribe(String[] topicFilters, int[] qos, String invocationContext, String activityToken, IMqttMessageListener[] messageListeners) {
 		service.traceDebug(TAG, "subscribe({" + Arrays.toString(topicFilters) + "}," + Arrays.toString(qos) + ",{"
 				+ invocationContext + "}, {" + activityToken + "}");
 		final Bundle resultBundle = new Bundle();
 		resultBundle.putString(MqttServiceConstants.CALLBACK_ACTION, MqttServiceConstants.SUBSCRIBE_ACTION);
 		resultBundle.putString(MqttServiceConstants.CALLBACK_ACTIVITY_TOKEN, activityToken);
 		resultBundle.putString(MqttServiceConstants.CALLBACK_INVOCATION_CONTEXT, invocationContext);
+
+		IMqttToken sendToken = null;
 		if((myClient != null) && (myClient.isConnected())){
 			IMqttActionListener listener = new MqttConnectionListener(resultBundle);
 			try {
-
-				myClient.subscribe(topicFilters, qos,messageListeners);
+				sendToken = myClient.subscribe(topicFilters, qos,messageListeners);
 			} catch (Exception e){
 				handleException(resultBundle, e);
 			}
@@ -707,19 +722,21 @@ class MqttConnection implements MqttCallbackExtended {
 			service.traceError("subscribe", NOT_CONNECTED);
 			service.callbackToActivity(clientHandle, Status.ERROR, resultBundle);
 		}
+		return sendToken;
 	}
 
-		/**
-         * Unsubscribe from a topic
-         *
-         * @param topic
-         *            a possibly wildcarded topic name
-         * @param invocationContext
-         *            arbitrary data to be passed back to the application
-         * @param activityToken
-         *            arbitrary identifier to be passed back to the Activity
-         */
-	void unsubscribe(final String topic, String invocationContext,
+	/**
+	 * Unsubscribe from a topic
+	 *
+	 * @param topic
+	 *            a possibly wildcarded topic name
+	 * @param invocationContext
+	 *            arbitrary data to be passed back to the application
+	 * @param activityToken
+	 *            arbitrary identifier to be passed back to the Activity
+	 * @return token for tracking the operation
+	 */
+	IMqttToken unsubscribe(final String topic, String invocationContext,
 			String activityToken) {
 		service.traceDebug(TAG, "unsubscribe({" + topic + "},{"
 				+ invocationContext + "}, {" + activityToken + "})");
@@ -731,11 +748,13 @@ class MqttConnection implements MqttCallbackExtended {
 		resultBundle.putString(
 				MqttServiceConstants.CALLBACK_INVOCATION_CONTEXT,
 				invocationContext);
+
+		IMqttToken sendToken = null;
 		if ((myClient != null) && (myClient.isConnected())) {
 			IMqttActionListener listener = new MqttConnectionListener(
 					resultBundle);
 			try {
-				myClient.unsubscribe(topic, invocationContext, listener);
+				sendToken = myClient.unsubscribe(topic, invocationContext, listener);
 			} catch (Exception e) {
 				handleException(resultBundle, e);
 			}
@@ -746,6 +765,7 @@ class MqttConnection implements MqttCallbackExtended {
 			service.traceError("subscribe", NOT_CONNECTED);
 			service.callbackToActivity(clientHandle, Status.ERROR, resultBundle);
 		}
+		return sendToken;
 	}
 
 	/**
@@ -757,8 +777,9 @@ class MqttConnection implements MqttCallbackExtended {
 	 *            arbitrary data to be passed back to the application
 	 * @param activityToken
 	 *            arbitrary identifier to be passed back to the Activity
+	 * @return token for tracking the operation
 	 */
-	void unsubscribe(final String[] topic, String invocationContext,
+	IMqttToken unsubscribe(final String[] topic, String invocationContext,
 			String activityToken) {
 		service.traceDebug(TAG, "unsubscribe({" + Arrays.toString(topic) + "},{"
 				+ invocationContext + "}, {" + activityToken + "})");
@@ -770,11 +791,13 @@ class MqttConnection implements MqttCallbackExtended {
 		resultBundle.putString(
 				MqttServiceConstants.CALLBACK_INVOCATION_CONTEXT,
 				invocationContext);
+
+		IMqttToken sendToken = null;
 		if ((myClient != null) && (myClient.isConnected())) {
 			IMqttActionListener listener = new MqttConnectionListener(
 					resultBundle);
 			try {
-				myClient.unsubscribe(topic, invocationContext, listener);
+				sendToken = myClient.unsubscribe(topic, invocationContext, listener);
 			} catch (Exception e) {
 				handleException(resultBundle, e);
 			}
@@ -785,6 +808,7 @@ class MqttConnection implements MqttCallbackExtended {
 			service.traceError("subscribe", NOT_CONNECTED);
 			service.callbackToActivity(clientHandle, Status.ERROR, resultBundle);
 		}
+		return sendToken;
 	}
 
 	/**

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttService.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttService.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.paho.client.mqttv3.DisconnectedBufferOptions;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.IMqttMessageListener;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
 import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
@@ -319,15 +320,15 @@ public class MqttService extends Service implements MqttTraceHandler {
    *            arbitrary data to be passed back to the application
    * @param activityToken
    *            arbitrary identifier to be passed back to the Activity
+   * @return token for tracking the operation
    * @throws MqttSecurityException thrown if there is a security exception
    * @throws MqttException thrown for all other MqttExceptions
    */
-  public void connect(String clientHandle, MqttConnectOptions connectOptions,
-      String invocationContext, String activityToken)
+  public IMqttToken connect(String clientHandle, MqttConnectOptions connectOptions,
+                            String invocationContext, String activityToken)
       throws MqttSecurityException, MqttException {
-	  	MqttConnection client = getConnection(clientHandle);
-	  	client.connect(connectOptions, null, activityToken);
-
+		MqttConnection client = getConnection(clientHandle);
+		return client.connect(connectOptions, null, activityToken);
   }
 
   /**
@@ -364,18 +365,19 @@ public class MqttService extends Service implements MqttTraceHandler {
    *            arbitrary data to be passed back to the application
    * @param activityToken
    *            arbitrary identifier to be passed back to the Activity
+   * @return token for tracking the operation
    */
-  public void disconnect(String clientHandle, String invocationContext,
+  public IMqttToken disconnect(String clientHandle, String invocationContext,
       String activityToken) {
     MqttConnection client = getConnection(clientHandle);
-    client.disconnect(invocationContext, activityToken);
+    IMqttToken sendToken = client.disconnect(invocationContext, activityToken);
     connections.remove(clientHandle);
-
 
     // the activity has finished using us, so we can stop the service
     // the activities are bound with BIND_AUTO_CREATE, so the service will
     // remain around until the last activity disconnects
     stopSelf();
+    return sendToken;
   }
 
   /**
@@ -389,17 +391,19 @@ public class MqttService extends Service implements MqttTraceHandler {
    *            arbitrary data to be passed back to the application
    * @param activityToken
    *            arbitrary identifier to be passed back to the Activity
+   * @return token for tracking the operation
    */
-  public void disconnect(String clientHandle, long quiesceTimeout,
+  public IMqttToken disconnect(String clientHandle, long quiesceTimeout,
       String invocationContext, String activityToken) {
     MqttConnection client = getConnection(clientHandle);
-    client.disconnect(quiesceTimeout, invocationContext, activityToken);
+    IMqttToken sendToken = client.disconnect(quiesceTimeout, invocationContext, activityToken);
     connections.remove(clientHandle);
 
     // the activity has finished using us, so we can stop the service
     // the activities are bound with BIND_AUTO_CREATE, so the service will
     // remain around until the last activity disconnects
     stopSelf();
+    return sendToken;
   }
 
   /**
@@ -475,11 +479,12 @@ public class MqttService extends Service implements MqttTraceHandler {
    *            arbitrary data to be passed back to the application
    * @param activityToken
    *            arbitrary identifier to be passed back to the Activity
+   * @return token for tracking the operation
    */
-  public void subscribe(String clientHandle, String topic, int qos,
+  public IMqttToken subscribe(String clientHandle, String topic, int qos,
       String invocationContext, String activityToken) {
     MqttConnection client = getConnection(clientHandle);
-    client.subscribe(topic, qos, invocationContext, activityToken);
+    return client.subscribe(topic, qos, invocationContext, activityToken);
   }
 
   /**
@@ -495,11 +500,12 @@ public class MqttService extends Service implements MqttTraceHandler {
    *            arbitrary data to be passed back to the application
    * @param activityToken
    *            arbitrary identifier to be passed back to the Activity
+   * @return token for tracking the operation
    */
-  public void subscribe(String clientHandle, String[] topic, int[] qos,
+  public IMqttToken subscribe(String clientHandle, String[] topic, int[] qos,
       String invocationContext, String activityToken) {
     MqttConnection client = getConnection(clientHandle);
-    client.subscribe(topic, qos, invocationContext, activityToken);
+    return client.subscribe(topic, qos, invocationContext, activityToken);
   }
 
   /**
@@ -516,10 +522,11 @@ public class MqttService extends Service implements MqttTraceHandler {
    * @param activityToken
    *            arbitrary identifier to be passed back to the Activity
    * @param messageListeners a callback to handle incoming messages
+   * @return token for tracking the operation
    */
-  public void subscribe(String clientHandle, String[] topicFilters, int[] qos, String invocationContext, String activityToken, IMqttMessageListener[] messageListeners){
+  public IMqttToken subscribe(String clientHandle, String[] topicFilters, int[] qos, String invocationContext, String activityToken, IMqttMessageListener[] messageListeners){
     MqttConnection client = getConnection(clientHandle);
-    client.subscribe(topicFilters, qos, invocationContext, activityToken, messageListeners);
+    return client.subscribe(topicFilters, qos, invocationContext, activityToken, messageListeners);
   }
 
   /**
@@ -533,11 +540,12 @@ public class MqttService extends Service implements MqttTraceHandler {
    *            arbitrary data to be passed back to the application
    * @param activityToken
    *            arbitrary identifier to be passed back to the Activity
+   * @return token for tracking the operation
    */
-  public void unsubscribe(String clientHandle, final String topic,
+  public IMqttToken unsubscribe(String clientHandle, final String topic,
       String invocationContext, String activityToken) {
     MqttConnection client = getConnection(clientHandle);
-    client.unsubscribe(topic, invocationContext, activityToken);
+    return client.unsubscribe(topic, invocationContext, activityToken);
   }
 
   /**
@@ -551,11 +559,12 @@ public class MqttService extends Service implements MqttTraceHandler {
    *            arbitrary data to be passed back to the application
    * @param activityToken
    *            arbitrary identifier to be passed back to the Activity
+   * @return token for tracking the operation
    */
-  public void unsubscribe(String clientHandle, final String[] topic,
+  public IMqttToken unsubscribe(String clientHandle, final String[] topic,
       String invocationContext, String activityToken) {
     MqttConnection client = getConnection(clientHandle);
-    client.unsubscribe(topic, invocationContext, activityToken);
+    return client.unsubscribe(topic, invocationContext, activityToken);
   }
 
   /**


### PR DESCRIPTION
Hi, I wanted to receive messageId when calling subscribe to make sure if subscribe actually succeeded or not by matching messageId.
This change will return IMqttToken instance, which contains messageId, when calling (dis)connect or (un)subscribe like publish does.

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [ ] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [ ] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
