### PR TITLE
Commenting compile.exclude on org.eclipse.paho.client.mqttv3 -- it wa…

### DIFF
--- a/paho.mqtt.android.example/build.gradle
+++ b/paho.mqtt.android.example/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     }
 }
 
-configurations.compile.exclude module: 'org.eclipse.paho.client.mqttv3'
+//configurations.compile.exclude module: 'org.eclipse.paho.client.mqttv3'
 task debug << {
     configurations.compile.each { println it}
 }

--- a/paho.mqtt.android.example/build.gradle
+++ b/paho.mqtt.android.example/build.gradle
@@ -43,7 +43,8 @@ dependencies {
     }
 }
 
-configurations.compile.exclude module: 'org.eclipse.paho.client.mqttv3'
+//configurations.compile.exclude module: 'org.eclipse.paho.client.mqttv3'
 task debug << {
     configurations.compile.each { println it}
 }
+

--- a/paho.mqtt.android.example/build.gradle
+++ b/paho.mqtt.android.example/build.gradle
@@ -43,8 +43,7 @@ dependencies {
     }
 }
 
-//configurations.compile.exclude module: 'org.eclipse.paho.client.mqttv3'
+configurations.compile.exclude module: 'org.eclipse.paho.client.mqttv3'
 task debug << {
     configurations.compile.each { println it}
 }
-


### PR DESCRIPTION
…s leading to class not found errors

Hi, I cloned the repository and tried to execute the example. The BUILD was failing because of class not found errors. I figured out that the compilation of the module org.eclipse.paho.client.mqttv3 was excluded. Commenting this line fixed the issue.

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
