### PR TITLE
support sessionPresent on connack

### DIFF
--- a/org.eclipse.paho.android.service/src/androidTest/java/org/eclipse/paho/android/AndroidServiceTest.java
+++ b/org.eclipse.paho.android.service/src/androidTest/java/org/eclipse/paho/android/AndroidServiceTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.paho.client.mqttv3.IMqttActionListener;
 import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.IMqttToken;
@@ -42,7 +43,21 @@ public class AndroidServiceTest extends AndroidTestCase {
         Log.d(TAG, properties.getServerSSLURI());
     }
 
+    private class MqttConnectCallback implements IMqttActionListener {
+        private IMqttToken asyncActionToken;
+        @Override
+        public void onSuccess(IMqttToken asyncActionToken) {
+            this.asyncActionToken = asyncActionToken;
+        }
 
+        @Override
+        public void onFailure(IMqttToken asyncActionToken, Throwable exception) {
+        }
+
+        public IMqttToken getAsyncActionToken() {
+            return asyncActionToken;
+        }
+    }
 
     /**
      * Tests that a client can be constructed and that it can connect to and
@@ -75,6 +90,52 @@ public class AndroidServiceTest extends AndroidTestCase {
         } finally {
             if(mqttclient != null){
                 mqttclient.close();
+            }
+        }
+    }
+
+    /**
+     * Tests that a client calls a callback with a token which sessionPresent is false.
+     *
+     * @throws Exception
+     */
+    public void testCleanSession() throws Exception {
+
+        IMqttAsyncClient mqttClient = null;
+        try {
+            mqttClient = new MqttAndroidClient(mContext,mqttServerURI, "testConnectWithCleanSession");
+            IMqttToken connectToken;
+            IMqttToken disconnectToken;
+            final MqttConnectOptions options1 = new MqttConnectOptions();
+            options1.setCleanSession(true);
+            final MqttConnectCallback connectCallback1 = new MqttConnectCallback();
+
+            connectToken = mqttClient.connect(options1, null, connectCallback1);
+            connectToken.waitForCompletion(waitForCompletionTime);
+
+            final IMqttToken connectedToken1 = connectCallback1.getAsyncActionToken();
+            assertFalse(connectedToken1.getSessionPresent());
+
+            disconnectToken = mqttClient.disconnect(null, null);
+            disconnectToken.waitForCompletion(waitForCompletionTime);
+
+            final MqttConnectOptions options2 = new MqttConnectOptions();
+            options1.setCleanSession(false);
+            final MqttConnectCallback connectCallback2 = new MqttConnectCallback();
+
+            connectToken = mqttClient.connect(options2, null, connectCallback2);
+            connectToken.waitForCompletion(waitForCompletionTime);
+
+            final IMqttToken connectedToken2 = connectCallback1.getAsyncActionToken();
+            assertTrue(connectedToken2.getSessionPresent());
+
+            disconnectToken = mqttClient.disconnect(null, null);
+            disconnectToken.waitForCompletion(waitForCompletionTime);
+        } catch (Exception exception){
+            fail("Failed: " + "testCleanSession" + " exception= " + exception);
+        } finally {
+            if(mqttClient != null){
+                mqttClient.close();
             }
         }
     }

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
@@ -1367,6 +1367,8 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 	 */
 	private void connectAction(Bundle data) {
 		IMqttToken token = connectToken;
+		((MqttTokenAndroid) token).setDelegate(
+				new MqttConnectTokenAndroid(data.getBoolean(MqttServiceConstants.SESSION_PRESENT)));
 		removeMqttToken(data);
 		
 		simpleAction(token, data);

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnectTokenAndroid.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnectTokenAndroid.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 1999, 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.paho.android.service;
+
+import org.eclipse.paho.client.mqttv3.IMqttActionListener;
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttWireMessage;
+
+/**
+ * <p>
+ * Implementation of the IMqttToken interface only for sessionPresent
+ */
+class MqttConnectTokenAndroid implements IMqttToken {
+    private boolean sessionPresent;
+
+    MqttConnectTokenAndroid( boolean sessionPresent) {
+        this.sessionPresent = sessionPresent;
+    }
+
+    void setMessage(MqttMessage message) {
+    }
+
+    void notifyDelivery(MqttMessage delivered) {
+    }
+
+    @Override
+    public void waitForCompletion() throws MqttException {
+
+    }
+
+    @Override
+    public void waitForCompletion(long timeout) throws MqttException {
+
+    }
+
+    @Override
+    public boolean isComplete() {
+        return false;
+    }
+
+    @Override
+    public MqttException getException() {
+        return null;
+    }
+
+    @Override
+    public void setActionCallback(IMqttActionListener listener) {
+
+    }
+
+    @Override
+    public IMqttActionListener getActionCallback() {
+        return null;
+    }
+
+    @Override
+    public IMqttAsyncClient getClient() {
+        return null;
+    }
+
+    @Override
+    public String[] getTopics() {
+        return new String[0];
+    }
+
+    @Override
+    public void setUserContext(Object userContext) {
+
+    }
+
+    @Override
+    public Object getUserContext() {
+        return null;
+    }
+
+    @Override
+    public int getMessageId() {
+        return 0;
+    }
+
+    @Override
+    public int[] getGrantedQos() {
+        return new int[0];
+    }
+
+    @Override
+    public boolean getSessionPresent() {
+        return this.sessionPresent;
+    }
+
+    @Override
+    public MqttWireMessage getResponse() {
+        return null;
+    }
+}

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
@@ -245,9 +245,9 @@ class MqttConnection implements MqttCallbackExtended {
 
 				@Override
 				public void onSuccess(IMqttToken asyncActionToken) {
-                    resultBundle.putBoolean(
-                            MqttServiceConstants.SESSION_PRESENT,
-                            asyncActionToken.getSessionPresent());
+					resultBundle.putBoolean(
+							MqttServiceConstants.SESSION_PRESENT,
+							asyncActionToken.getSessionPresent());
 					doAfterConnectSuccess(resultBundle);
 					service.traceDebug(TAG, "connect success!");
 				}
@@ -1076,9 +1076,9 @@ class MqttConnection implements MqttCallbackExtended {
 						// wakelock and drop it later.
 						service.traceDebug(TAG,"Reconnect Success!");
 						service.traceDebug(TAG,"DeliverBacklog when reconnect.");
-                        resultBundle.putBoolean(
-                                MqttServiceConstants.SESSION_PRESENT,
-                                asyncActionToken.getSessionPresent());
+						resultBundle.putBoolean(
+								MqttServiceConstants.SESSION_PRESENT,
+								asyncActionToken.getSessionPresent());
 						doAfterConnectSuccess(resultBundle);
 					}
 					

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
@@ -245,6 +245,9 @@ class MqttConnection implements MqttCallbackExtended {
 
 				@Override
 				public void onSuccess(IMqttToken asyncActionToken) {
+                    resultBundle.putBoolean(
+                            MqttServiceConstants.SESSION_PRESENT,
+                            asyncActionToken.getSessionPresent());
 					doAfterConnectSuccess(resultBundle);
 					service.traceDebug(TAG, "connect success!");
 				}
@@ -1073,6 +1076,9 @@ class MqttConnection implements MqttCallbackExtended {
 						// wakelock and drop it later.
 						service.traceDebug(TAG,"Reconnect Success!");
 						service.traceDebug(TAG,"DeliverBacklog when reconnect.");
+                        resultBundle.putBoolean(
+                                MqttServiceConstants.SESSION_PRESENT,
+                                asyncActionToken.getSessionPresent());
 						doAfterConnectSuccess(resultBundle);
 					}
 					

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttServiceConstants.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttServiceConstants.java
@@ -34,6 +34,7 @@ interface MqttServiceConstants {
   String DESTINATION_NAME = "destinationName";
   String CLIENT_HANDLE = "clientHandle";
   String MESSAGE_ID = "messageId";
+  String SESSION_PRESENT = "sessionPresent";
 
   /* Tags for actions passed between the Activity and the Service */
   String SEND_ACTION = "send";


### PR DESCRIPTION
Transfer a sessionPresent flag on a CONNACK token from Paho-Java to Paho-Android. fix #200

Signed-off-by: yonishi <vivre214@gmail.com>

- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
