### PR TITLE
Revert "Resolve confusing dependency management and Move from minSDK 9 to min 14"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,9 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
-        google()
     }
     dependencies {
-	    classpath 'com.android.tools.build:gradle:3.0.0-beta5'
+	    classpath 'com.android.tools.build:gradle:2.2.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -15,9 +14,8 @@ buildscript {
 
 ext{
 
-    compileSdkVersion = 26
-    buildToolsVersion = '26.0.0'
-    supportLibVersion = '26.1.0'
+    compileSdkVersion = 24
+    buildToolsVersion = '23.0.3'
 
 
     group = 'org.eclipse.paho'
@@ -32,6 +30,7 @@ ext{
 
     mavenUrl = "https://repo.eclipse.org/content/repositories/paho-releases/"
 
+    supportLibVersion = '24.2.1'
 
 }
 
@@ -52,6 +51,9 @@ def androidHomeIsDefined = androidHome?.trim()
 
 def sdkDir = androidHomeIsDefined ? androidHome : getSdkDirFromLocalProperties()
 
+println "SDK dir: $sdkDir"
+
+
 allprojects {
 
     repositories {
@@ -59,7 +61,6 @@ allprojects {
         maven {
             url "file://$sdkDir/extras/android/m2repository/"
         }
-        google()
     }
 
     version = rootProject.ext.serviceVersion

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 04 11:50:11 BST 2017
+#Tue Jan 24 11:18:55 GMT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/org.eclipse.paho.android.sample/build.gradle
+++ b/org.eclipse.paho.android.sample/build.gradle
@@ -7,12 +7,21 @@ android {
     defaultConfig {
         applicationId rootProject.ext.sampleArchivesBaseName
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 24
         versionCode 1
         versionName "0.1"
     }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
     lintOptions {
         abortOnError false
+    }
+    dexOptions {
+        preDexLibraries = false
     }
 }
 
@@ -23,15 +32,23 @@ repositories {
 
 
 dependencies {
-    compile project(':org.eclipse.paho.android.service')
-//    compile "org.eclipse.paho:org.eclipse.paho.client.mqttv3:${rootProject.ext.clientVersion}"
-//    compile "org.eclipse.paho:org.eclipse.paho.android.service:${rootProject.ext.clientVersion}"
-
+    //compile fileTree(dir: '../org.eclipse.paho.android/service/libs', excludes: ["org.eclipse.paho.client.mqttv3-${rootProject.ext.clientVersion}.jar"], include: '')
     compile "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     compile "com.android.support:recyclerview-v7:${rootProject.ext.supportLibVersion}"
+    compile "org.eclipse.paho:org.eclipse.paho.client.mqttv3:${rootProject.ext.clientVersion}"
+    compile (project(':org.eclipse.paho.android.service')){
+        //exclude module: "org.eclipse.paho.client.mqttv3"
+        transitive=true
+    }
 }
 
 task publishAPK(type: Copy) {
     from file("${project.buildDir}/outputs/apk/" + rootProject.ext.sampleArchivesBaseName + "-debug.apk");
     into '/shared/technology/paho/Android/' + rootProject.ext.sampleVersion + '/debug/';
+}
+
+
+configurations.compile.exclude module: 'org.eclipse.paho.client.mqttv3'
+task debug << {
+    configurations.compile.each { println it}
 }

--- a/org.eclipse.paho.android.sample/proguard-rules.pro
+++ b/org.eclipse.paho.android.sample/proguard-rules.pro
@@ -1,0 +1,17 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /home/james/Android/Sdk/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}

--- a/org.eclipse.paho.android.sample/src/main/AndroidManifest.xml
+++ b/org.eclipse.paho.android.sample/src/main/AndroidManifest.xml
@@ -5,8 +5,14 @@
 
 
     <!-- Permissions the Application Requires -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <!--<uses-permission android:name="android.permission.READ_PHONE_STATE" />-->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
 
     <application
         android:allowBackup="false"
@@ -27,6 +33,9 @@
 
         </activity>
 
+        <!-- Mqtt Service -->
+        <service android:name="org.eclipse.paho.android.service.MqttService">
+        </service>
     </application>
 
 </manifest>

--- a/org.eclipse.paho.android.service/build.gradle
+++ b/org.eclipse.paho.android.service/build.gradle
@@ -6,10 +6,20 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 9
         targetSdkVersion 24
 
         testApplicationId "org.eclipse.paho.android.service.test"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    dexOptions {
+        preDexLibraries = false
     }
 
     lintOptions {
@@ -21,9 +31,14 @@ repositories {
     maven { url rootProject.ext.mavenUrl }
 }
 
+configurations {
+   //androidTestCompile.exclude module: 'org.eclipse.paho.client.mqttv3'
+}
+
 dependencies {
     compile "org.eclipse.paho:org.eclipse.paho.client.mqttv3:${rootProject.ext.clientVersion}"
     compile "com.android.support:support-v4:${rootProject.ext.supportLibVersion}"
+    compile fileTree(include: ['*.jar'], dir: 'libs')
 }
 
 android.libraryVariants.all { variant ->
@@ -45,6 +60,14 @@ android.libraryVariants.all { variant ->
 task("generateSourcesJar", type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
+}
+
+// Copy the Paho Java client into the libs directory to bundle it with the AAR
+task("copyLibs", type: Copy) {
+    println "Copying MQTT Jar into libs directory"
+    from configurations.compile
+    into 'libs'
+    include 'org.eclipse.paho*'
 }
 
 // Renames the Release AAR file to a maven convention
@@ -95,6 +118,17 @@ publishing {
 }
 
 
+task debug << {
+    configurations.compile.each { println it}
+}
+// Required to bundle Java library Jar in AAR
+clean.doLast{
+    copyLibs.execute()
+}
 assemble.doLast {
     renameReleaseAAR.execute()
+}
+
+clean.doFirst {
+    delete 'libs'
 }

--- a/org.eclipse.paho.android.service/proguard-rules.pro
+++ b/org.eclipse.paho.android.service/proguard-rules.pro
@@ -1,0 +1,17 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /home/james/Android/Sdk/tools/proguard/proguard-org.eclipse.paho.android.service.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}

--- a/org.eclipse.paho.android.service/src/main/AndroidManifest.xml
+++ b/org.eclipse.paho.android.service/src/main/AndroidManifest.xml
@@ -1,14 +1,7 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="org.eclipse.paho.android.service">
+<manifest
+    package="org.eclipse.paho.android.service">
 
-  <uses-permission android:name="android.permission.WAKE_LOCK" />
-  <uses-permission android:name="android.permission.INTERNET" />
-
-  <application>
-
-    <!-- Mqtt Service -->
-    <service android:name="org.eclipse.paho.android.service.MqttService" />
-
-  </application>
+    <application>
+    </application>
 
 </manifest>

--- a/paho.mqtt.android.example/build.gradle
+++ b/paho.mqtt.android.example/build.gradle
@@ -7,9 +7,18 @@ android {
     defaultConfig {
         applicationId "paho.mqtt.java.example"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    dexOptions {
+        preDexLibraries = false
     }
     lintOptions {
         abortOnError false
@@ -22,12 +31,19 @@ repositories {
 
 
 dependencies {
-    compile project(':org.eclipse.paho.android.service')
-//    compile "org.eclipse.paho:org.eclipse.paho.client.mqttv3:${rootProject.ext.clientVersion}"
-//    compile "org.eclipse.paho:org.eclipse.paho.android.service:${rootProject.ext.clientVersion}"
+    compile fileTree(dir: 'libs', excludes: ["org.eclipse.paho.client.mqttv3-${rootProject.ext.clientVersion}.jar"], include: '*.jar')
+    testCompile 'junit:junit:4.12'
     compile "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     compile "com.android.support:design:${rootProject.ext.supportLibVersion}"
     compile "com.android.support:recyclerview-v7:${rootProject.ext.supportLibVersion}"
+    compile "org.eclipse.paho:org.eclipse.paho.client.mqttv3:${rootProject.ext.clientVersion}"
+    compile (project(':org.eclipse.paho.android.service')){
+        //exclude module: "org.eclipse.paho.client.mqttv3"
+        transitive=true
+    }
+}
 
-    testCompile 'junit:junit:4.12'
+configurations.compile.exclude module: 'org.eclipse.paho.client.mqttv3'
+task debug << {
+    configurations.compile.each { println it}
 }

--- a/paho.mqtt.android.example/proguard-rules.pro
+++ b/paho.mqtt.android.example/proguard-rules.pro
@@ -1,0 +1,17 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /home/james/Android/Sdk/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}

--- a/paho.mqtt.android.example/src/main/AndroidManifest.xml
+++ b/paho.mqtt.android.example/src/main/AndroidManifest.xml
@@ -5,8 +5,13 @@
 
 
     <!-- Permissions the Application Requires -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <!--<uses-permission android:name="android.permission.READ_PHONE_STATE" />-->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="false"
@@ -25,7 +30,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
+        <!-- Mqtt Service -->
+        <service android:name="org.eclipse.paho.android.service.MqttService">
+        </service>
     </application>
 
 </manifest>


### PR DESCRIPTION
Reverts eclipse/paho.mqtt.android#245 as it should have pointed at the develop branch instead of master.