### PR TITLE
Thow Invalid Argument Exception when getConnection is called with a null clientHandle

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttService.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttService.java
@@ -577,6 +577,9 @@ public class MqttService extends Service implements MqttTraceHandler {
    * @return the MqttConnection identified by this handle
    */
   private MqttConnection getConnection(String clientHandle) {
+    if(clientHandle == null){
+      throw new IllegalArgumentException("Invalid ClientHandle");
+    }
     MqttConnection client = connections.get(clientHandle);
     if (client == null) {
       throw new IllegalArgumentException("Invalid ClientHandle");


### PR DESCRIPTION
Whilst not resolving them, this will provide further information to users who see the following error: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.Object.hashCode()' on a null object reference
Resolving (partially) Issues:
- #99 
- #183 
- #206

Signed-off-by: James Sutton <james.sutton@uk.ibm.com>
