### PR TITLE
Support message buffering before initial connect

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttService.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttService.java
@@ -287,8 +287,9 @@ public class MqttService extends Service implements MqttTraceHandler {
      * @param persistence specifies the persistence layer to be used with this client
      * @return a string to be used by the Activity as a "handle" for this
      * MqttConnection
+     * @throws MqttException thrown if failed to create client
      */
-    public String getClient(String serverURI, String clientId, String contextId, MqttClientPersistence persistence) {
+    public String getClient(String serverURI, String clientId, String contextId, MqttClientPersistence persistence) throws MqttException {
         String clientHandle = serverURI + ":" + clientId + ":" + contextId;
         if (!connections.containsKey(clientHandle)) {
             MqttConnection client = new MqttConnection(this, serverURI, clientId, persistence, clientHandle);
@@ -345,7 +346,6 @@ public class MqttService extends Service implements MqttTraceHandler {
     public void disconnect(String clientHandle, String invocationContext, String activityToken) {
         MqttConnection client = getConnection(clientHandle);
         client.disconnect(invocationContext, activityToken);
-        connections.remove(clientHandle);
 
 
         // the activity has finished using us, so we can stop the service
@@ -365,7 +365,6 @@ public class MqttService extends Service implements MqttTraceHandler {
     public void disconnect(String clientHandle, long quiesceTimeout, String invocationContext, String activityToken) {
         MqttConnection client = getConnection(clientHandle);
         client.disconnect(quiesceTimeout, invocationContext, activityToken);
-        connections.remove(clientHandle);
 
         // the activity has finished using us, so we can stop the service
         // the activities are bound with BIND_AUTO_CREATE, so the service will
@@ -498,22 +497,22 @@ public class MqttService extends Service implements MqttTraceHandler {
         return client.getPendingDeliveryTokens();
     }
 
-  /**
-   * Get the MqttConnection identified by this client handle
-   *
-   * @param clientHandle identifies the MqttConnection
-   * @return the MqttConnection identified by this handle
-   */
-  private MqttConnection getConnection(String clientHandle) {
-    if(clientHandle == null){
-      throw new IllegalArgumentException("Invalid ClientHandle");
+    /**
+     * Get the MqttConnection identified by this client handle
+     *
+     * @param clientHandle identifies the MqttConnection
+     * @return the MqttConnection identified by this handle
+     */
+    private MqttConnection getConnection(String clientHandle) {
+        if (clientHandle == null) {
+            throw new IllegalArgumentException("Invalid ClientHandle");
+        }
+        MqttConnection client = connections.get(clientHandle);
+        if (client == null) {
+            throw new IllegalArgumentException("Invalid ClientHandle");
+        }
+        return client;
     }
-    MqttConnection client = connections.get(clientHandle);
-    if (client == null) {
-      throw new IllegalArgumentException("Invalid ClientHandle");
-    }
-    return client;
-  }
 
     /**
      * Called by the Activity when a message has been passed back to the


### PR DESCRIPTION
The codeformatting changes to develop caused code conflicts in PR #198. This is the same PR but with the code conflicts removed. All code changes should be attributed to @matsukaz as he was the original contributor. Submitting a new PR as I don't have access to update the original PR

This should resolve issue #197 

Original PR description
> This change will enable offline buffering even if initial connection has never been established yet.
> 
> I've changed MqttAndoidClient, MqttService, MqttConnection in order to instantiate these instances before connection get established.

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
