### PR TITLE
Avoids ClassCastException when there are more than one service

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
@@ -1517,11 +1517,13 @@ public class MqttAndroidClient extends BroadcastReceiver implements IMqttAsyncCl
 
         @Override
         public void onServiceConnected(ComponentName name, IBinder binder) {
-            mqttService = ((MqttServiceBinder) binder).getService();
-            bindedService = true;
-            // now that we have the service available, we can actually
-            // connect...
-            doConnect();
+            if (MqttServiceBinder.class.isAssignableFrom(binder.getClass())) {
+                mqttService = ((MqttServiceBinder) binder).getService();
+                bindedService = true;
+                // now that we have the service available, we can actually
+                // connect...
+                doConnect();
+            }
         }
 
         @Override


### PR DESCRIPTION
This solves a problem that we faced when we have more than one service in Android and one of them is MqttService. I provide these links of StackOverflow which tells about the problem. It also has to do with Issue #163 and #110 

[android.os.BinderProxy cannot be cast to org.eclipse.paho.android.service.MqttServiceBinder](https://stackoverflow.com/questions/39348444/android-os-binderproxy-cannot-be-cast-to-org-eclipse-paho-android-service-mqttse)
[put service into separate process, cause bind exception #163](https://github.com/eclipse/paho.mqtt.android/issues/163)
[Strange ClassCastException crash in MqttAndroidClient #110](https://github.com/eclipse/paho.mqtt.android/issues/110)

I've tested [the solution](https://stackoverflow.com/questions/39348444/android-os-binderproxy-cannot-be-cast-to-org-eclipse-paho-android-service-mqttse/48878872#48878872) that I provided in StackOverflow and it's working.

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [v] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [v] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [v] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [v] If this is new functionality, You have added the appropriate Unit tests.
