### PR TITLE
update to Android Studio 3.3.2

### DIFF
--- a/BasicExample/build.gradle
+++ b/BasicExample/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId "paho.mqtt.java.example"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,16 +7,16 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
 ext {
-    compileSdkVersion = 26
-    buildToolsVersion = '26.0.3'
-    supportLibVersion = '27.0.2'
+    compileSdkVersion = 28
+    buildToolsVersion = '28.0.3'
+    supportLibVersion = '28.0.0'
 
     group = 'org.eclipse.paho'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/org.eclipse.paho.android.sample/build.gradle
+++ b/org.eclipse.paho.android.sample/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId rootProject.ext.sampleArchivesBaseName
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "0.1"
     }

--- a/org.eclipse.paho.android.service/build.gradle
+++ b/org.eclipse.paho.android.service/build.gradle
@@ -29,12 +29,14 @@ dependencies {
 
 android.libraryVariants.all { variant ->
     task("generate${variant.name}Javadoc", type: Javadoc) {
+        doFirst {
+            ext.androidJar =
+                    "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
+            classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+        }
         title = "$name $version API"
         description "Generates Javadoc for $variant.name."
-        source = variant.javaCompile.source
-        ext.androidJar =
-                "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
-        classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+        source = variant.javaCompileProvider
         options.links("http://docs.oracle.com/javase/7/docs/api/")
         options.links("http://d.android.com/reference/")
         exclude '**/BuildConfig.java'


### PR DESCRIPTION
Update to Android Studio 3.3.2. Fixed the gradle sync error with JavaDoc in build.gradle of the service module.

Signed-off-by: Alan Lyu <pocktynox@gmail.com>
