### PR TITLE
Use AndroidHighResolutionTimer for elapsed time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext{
     serviceArchivesBaseName = 'org.eclipse.paho.android.service'
     serviceVersion = '1.1.1'
 
-    clientVersion = '1.1.0'
+    clientVersion = '1.2.5'
 
     mavenUrl = "https://repo.eclipse.org/content/repositories/paho-releases/"
 

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/AndroidHighResolutionTimer.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/AndroidHighResolutionTimer.java
@@ -1,0 +1,24 @@
+package org.eclipse.paho.android.service;
+
+import android.os.Build;
+import android.os.SystemClock;
+
+import org.eclipse.paho.client.mqttv3.internal.HighResolutionTimer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An android {@code HighResolutionTimer} implementation that includes the time spent asleep.
+ */
+public class AndroidHighResolutionTimer implements HighResolutionTimer {
+    @Override
+    public long nanoTime() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            return SystemClock.elapsedRealtimeNanos();
+        } else {
+            // Use the old currentTimeMillis implementation in API levels that don't support elapsedRealtimeNanos
+            // See: https://github.com/eclipse/paho.mqtt.java/issues/278
+            return TimeUnit.NANOSECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttConnection.java
@@ -287,7 +287,8 @@ class MqttConnection implements MqttCallbackExtended {
 			else {
 				alarmPingSender = new AlarmPingSender(service);
 				myClient = new MqttAsyncClient(serverURI, clientId,
-						persistence, alarmPingSender);
+						persistence, alarmPingSender, null,
+						new AndroidHighResolutionTimer());
 				myClient.setCallback(this);
 
 				service.traceDebug(TAG,"Do Real connect!");


### PR DESCRIPTION
This timer uses SystemClock.elapsedRealtimeNanos to calculate the high
resolution timing value, which advances time when the device is asleep.

Fixes a bug introduced by the paho.mqtt.java library when it was changed
to track elapsed time using System.nanoTime. However, on android,
nanoTime does not advance when the device is in a deep sleep. As a
result, pings may not be sent frequently enough, resulting in client
disconnects.

See:
https://github.com/eclipse/paho.mqtt.java/issues/278
https://github.com/eclipse/paho.mqtt.java/issues/774

Signed-off-by: Dustin Thomson <dthomson@51systems.com>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [x] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [x] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [x] If this is new functionality, You have added the appropriate Unit tests.
