### PR TITLE
Fix  subscribe method with IMqttMessageListener

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
@@ -1146,7 +1146,7 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 		String activityToken = storeToken(token);
 		mqttService.subscribe(clientHandle, topicFilters, qos, null, activityToken, messageListeners);
 
-		return null;
+		return token;
 	}
 
 


### PR DESCRIPTION
- [ ] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [ ] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [x] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.

Possible error: [subscribe have no call back when the message arrived when i use this method "public IMqttToken subscribe(String[] topicFilters, int[] qos, IMqttMessageListener[] messageListeners)"]( https://github.com/eclipse/paho.mqtt.android/issues/262#issue-274048357) can be fixed like this.