### PR TITLE
Receive messages on a non-UI thread

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttAndroidClient.java
@@ -54,6 +54,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.IBinder;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.SparseArray;
@@ -444,11 +445,18 @@ public class MqttAndroidClient extends BroadcastReceiver implements
 		return token;
 	}
 
+	private Handler handler;
 	private void registerReceiver(BroadcastReceiver receiver) {
+		if (handler == null) {
+			HandlerThread handlerThread = new HandlerThread("MyNewThread");
+			handlerThread.start();
+			Looper looper = handlerThread.getLooper();
+			handler = new Handler(looper);
+		}
 		IntentFilter filter = new IntentFilter();
-				filter.addAction(MqttServiceConstants.CALLBACK_TO_ACTIVITY);
-				LocalBroadcastManager.getInstance(myContext).registerReceiver(receiver, filter);
-				receiverRegistered = true;
+		filter.addAction(MqttServiceConstants.CALLBACK_TO_ACTIVITY);
+		myContext.registerReceiver(receiver, filter, null, handler);
+		receiverRegistered = true;
 	}
 
 	/**

--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttService.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/MqttService.java
@@ -283,7 +283,7 @@ public class MqttService extends Service implements MqttTraceHandler {
     if (dataBundle != null) {
       callbackIntent.putExtras(dataBundle);
     }
-    LocalBroadcastManager.getInstance(this).sendBroadcast(callbackIntent);
+    sendBroadcast(callbackIntent);
   }
 
   // The major API implementation follows :-


### PR DESCRIPTION
When setting a new callback, messages are received on the UI thread. This completely locks up the UI if there are lots of messages being received. This has been discussed before here: https://github.com/eclipse/paho.mqtt.android/issues/207, but it seems that the solution was never implemented.

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [X] You have signed the [Eclipse ECA](https://wiki.eclipse.org/ECA)
- [X] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [X] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
